### PR TITLE
Require yaml>=5.3

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -7,7 +7,7 @@ setup(
     packages=find_packages(include=['{{ cookiecutter.project_slug }}', '{{ cookiecutter.project_slug }}.*']),
     python_requires='>={{ cookiecutter.python_version }}',
     install_requires=[
-        'flake8', 'tqdm', 'mlflow', 'orion', 'pyyaml', 'pytest',
+        'flake8', 'tqdm', 'mlflow', 'orion', 'pyyaml>=5.3', 'pytest',
         {%- if cookiecutter.dl_framework == 'pytorch' %}
         'torch'],
         {%- endif %}


### PR DESCRIPTION
When using yaml version 3.13 I got the following error:

`WARNING:voicemd.main:module 'yaml' has no attribute 'FullLoader'`

Note that this was using python 3.7.6. Updating to yaml 5.3 fixed this issue. This will ensure the proper yaml version is installed.