### PR TITLE
Update missing dependency for doc generation

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -33,6 +33,7 @@ extensions.append('recommonmark')
 
 # use the readthedocs theme
 extensions.append('sphinx_rtd_theme')
+extensions.append('sphinxcontrib.napoleon')
 
 # autoapi extension for doc strings
 extensions.append('autoapi.extension')

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -17,6 +17,7 @@ setup(
         'sphinx',
         'sphinx-autoapi',
         'sphinx-rtd-theme',
+        'sphinxcontrib-napoleon',
         'recommonmark',
         {%- if cookiecutter.dl_framework == 'pytorch' %}
         'torch'],


### PR DESCRIPTION
Docstring args werent being parsed properly due to missing extension, it was raising unnecessary warnings and didn't render args properly in the docs.

This fixes this.